### PR TITLE
Completion/getopt: compatibility & reliability

### DIFF
--- a/clean_files.txt
+++ b/clean_files.txt
@@ -49,6 +49,7 @@ completion/available/docker-machine.completion.bash
 completion/available/docker.completion.bash
 completion/available/gcloud.completion.bash
 completion/available/gem.completion.bash
+completion/available/getopt.completion.bash
 completion/available/git.completion.bash
 completion/available/github-cli.completion.bash
 completion/available/go.completion.bash

--- a/completion/available/getopt.completion.bash
+++ b/completion/available/getopt.completion.bash
@@ -21,15 +21,15 @@ function _getopt() {
 
 	case $prev in
 		-s | --shell)
-			read -d '' -ra COMPREPLY < <(compgen -W "${SHELL_ARGS[*]}" -- "$cur")
+			COMPREPLY=("${SHELL_ARGS[@]}")
 			;;
 		-n | --name)
 			read -d '' -ra COMPREPLY < <(compgen -A function -- "$cur")
 			;;
 		*)
-			read -d '' -ra COMPREPLY < <(compgen -W "${OPTIONS[*]}" -- "$cur")
+			COMPREPLY=("${OPTIONS[@]}")
 			;;
 	esac
 }
 
-complete -F _getopt getopt
+complete -F _getopt -X '!&*' getopt

--- a/completion/available/getopt.completion.bash
+++ b/completion/available/getopt.completion.bash
@@ -1,32 +1,34 @@
-__getopt() {
-  local OPTIONS=('-a' '--alternative'
-    '-h' '--help'
-    '-l' '--longoptions'
-    '-n' '--name'
-    '-o' '--options'
-    '-q' '--quiet'
-    '-Q' '--quiet-output'
-    '-s' '--shell'
-    '-T' '--test'
-    '-u' '--unquoted'
-    '-V' '--version')
+# shellcheck shell=bash
 
-  local SHELL_ARGS=('sh' 'bash' 'csh' 'tcsh')
+function _getopt() {
+	local OPTIONS=('-a' '--alternative'
+		'-h' '--help'
+		'-l' '--longoptions'
+		'-n' '--name'
+		'-o' '--options'
+		'-q' '--quiet'
+		'-Q' '--quiet-output'
+		'-s' '--shell'
+		'-T' '--test'
+		'-u' '--unquoted'
+		'-V' '--version')
 
-  local current=$2
-  local previous=$3
+	local SHELL_ARGS=('sh' 'bash' 'csh' 'tcsh')
 
-  case $previous in
-    -s|--shell)
-      readarray -t COMPREPLY < <(compgen -W "${SHELL_ARGS[*]}" -- "$current")
-      ;;
-    -n|--name)
-      readarray -t COMPREPLY < <(compgen -A function -- "$current")
-      ;;
-    *)
-      readarray -t COMPREPLY < <(compgen -W "${OPTIONS[*]}" -- "$current")
-      ;;
-  esac
+	local current=$2
+	local previous=$3
+
+	case $previous in
+		-s | --shell)
+			readarray -t COMPREPLY < <(compgen -W "${SHELL_ARGS[*]}" -- "$current")
+			;;
+		-n | --name)
+			readarray -t COMPREPLY < <(compgen -A function -- "$current")
+			;;
+		*)
+			readarray -t COMPREPLY < <(compgen -W "${OPTIONS[*]}" -- "$current")
+			;;
+	esac
 }
 
-complete -F __getopt getopt
+complete -F _getopt getopt

--- a/completion/available/getopt.completion.bash
+++ b/completion/available/getopt.completion.bash
@@ -1,6 +1,10 @@
 # shellcheck shell=bash
 
 function _getopt() {
+	local IFS=$'\n'
+	local cur=${COMP_WORDS[COMP_CWORD]}
+	local prev=${COMP_WORDS[COMP_CWORD-1]:-}
+
 	local OPTIONS=('-a' '--alternative'
 		'-h' '--help'
 		'-l' '--longoptions'
@@ -15,18 +19,15 @@ function _getopt() {
 
 	local SHELL_ARGS=('sh' 'bash' 'csh' 'tcsh')
 
-	local current=$2
-	local previous=$3
-
-	case $previous in
+	case $prev in
 		-s | --shell)
-			readarray -t COMPREPLY < <(compgen -W "${SHELL_ARGS[*]}" -- "$current")
+			read -d '' -ra COMPREPLY < <(compgen -W "${SHELL_ARGS[*]}" -- "$cur")
 			;;
 		-n | --name)
-			readarray -t COMPREPLY < <(compgen -A function -- "$current")
+			read -d '' -ra COMPREPLY < <(compgen -A function -- "$cur")
 			;;
 		*)
-			readarray -t COMPREPLY < <(compgen -W "${OPTIONS[*]}" -- "$current")
+			read -d '' -ra COMPREPLY < <(compgen -W "${OPTIONS[*]}" -- "$cur")
 			;;
 	esac
 }


### PR DESCRIPTION
## Description
This is meant to simplify the completion code, improve reliability by not re-parsing candidates, and add compatibility with Bash v3.2.

- run `shfmt -w completion/available/getopt.completion.bash` for formatting,
- run `shellcheck completion/available getopt.completion.bash` to check for errors/omissions/mistakes,
- use `IFS=$'\n' read -d '' -ra` instead of `readarray -t`, for compatibility with _Bash_ v3.2,
- use `-X '!&*'` to avoid needing to run `compgen -W` at all,
- use more common completion function boilerplate, since it's the same on every darn function might as well just keep it simple 😃.

## Motivation and Context
Just trying to help out 😆 

If you accept this PR on your fork, then your PR on the main repo will get automatically updated 👍 

## How Has This Been Tested?
Works for me!

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] If I have added a new file, I also added it to ``clean_files.txt`` and formatted it using ``lint_clean_files.sh``.
- [ ] I have added tests to cover my changes, and all the new and existing tests pass.
